### PR TITLE
Change to depend only on the used TTY components

### DIFF
--- a/hammerhead.gemspec
+++ b/hammerhead.gemspec
@@ -37,9 +37,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
-  # NOTE: Watch for a new release of TTY, and then change these dependencies.
-  spec.add_dependency 'bundler', '~> 1.16', '< 2.0'
-  spec.add_dependency 'tty', '~> 0.10.0'
+  # Add TTY components
+  spec.add_dependency 'tty-config', '~> 0.4.0'
+  spec.add_dependency 'tty-logger', '~> 0.5.0'
+  spec.add_dependency 'tty-table', '~> 0.12.0'
 
   spec.add_dependency 'harvested', ['~> 4.0']
 end

--- a/lib/hammerhead/command.rb
+++ b/lib/hammerhead/command.rb
@@ -1,118 +1,12 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-
 module Hammerhead
   class Command # :nodoc: all
-    extend Forwardable
-
-    def_delegators :command, :run
-
     # Execute this command
     #
     # @api public
     def execute
       raise NotImplementedError, "#{self.class}##{__method__} must be implemented"
-    end
-
-    # The external commands runner
-    #
-    # @see http://www.rubydoc.info/gems/tty-command
-    #
-    # @api public
-    def command **options
-      require 'tty-command'
-      TTY::Command.new(options)
-    end
-
-    # The cursor movement
-    #
-    # @see http://www.rubydoc.info/gems/tty-cursor
-    #
-    # @api public
-    def cursor
-      require 'tty-cursor'
-      TTY::Cursor
-    end
-
-    # Open a file or text in the user's preferred editor
-    #
-    # @see http://www.rubydoc.info/gems/tty-editor
-    #
-    # @api public
-    def editor
-      require 'tty-editor'
-      TTY::Editor
-    end
-
-    # File manipulation utility methods
-    #
-    # @see http://www.rubydoc.info/gems/tty-file
-    #
-    # @api public
-    def generator
-      require 'tty-file'
-      TTY::File
-    end
-
-    # Terminal output paging
-    #
-    # @see http://www.rubydoc.info/gems/tty-pager
-    #
-    # @api public
-    def pager **options
-      require 'tty-pager'
-      TTY::Pager.new(options)
-    end
-
-    # Terminal platform and OS properties
-    #
-    # @see http://www.rubydoc.info/gems/tty-pager
-    #
-    # @api public
-    def platform
-      require 'tty-platform'
-      TTY::Platform.new
-    end
-
-    # The interactive prompt
-    #
-    # @see http://www.rubydoc.info/gems/tty-prompt
-    #
-    # @api public
-    def prompt **options
-      require 'tty-prompt'
-      TTY::Prompt.new(options)
-    end
-
-    # Get terminal screen properties
-    #
-    # @see http://www.rubydoc.info/gems/tty-screen
-    #
-    # @api public
-    def screen
-      require 'tty-screen'
-      TTY::Screen
-    end
-
-    # The unix which utility
-    #
-    # @see http://www.rubydoc.info/gems/tty-which
-    #
-    # @api public
-    def which *args
-      require 'tty-which'
-      TTY::Which.which(*args)
-    end
-
-    # Check if executable exists
-    #
-    # @see http://www.rubydoc.info/gems/tty-which
-    #
-    # @api public
-    def exec_exist? *args
-      require 'tty-which'
-      TTY::Which.exist?(*args)
     end
   end
 end


### PR DESCRIPTION
Thank you for using `tty` gem! Much appreciated.

I reviewed your gem and noticed dependency on `tty` gem. In general, a gem shouldn't need to depend on the `tty` gem. The `tty` gem itself is only used to scaffold a new CLI application. Once generated, the gem needs to use only the TTY components it requires. I admit the generator doesn't make this easy and clear and I will make sure that the next releases of `tty` improve on this situation and make the process better. There is already a solution in the works for the next release.

Given the above, I went ahead and replaced the `tty` runtime dependency with actually used TTY components and removed references to components that are not used. I also removed the bundler dependency as it's only needed by `tty` gem and I have future plans to remove `bundler` as a dependency altogether.